### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/bharathraj1614/cc21f1b1-ef46-4003-9419-7b6ac69c648b/f12ce632-e442-49c3-aa93-5db5e34fc3e4/_apis/work/boardbadge/cc73e012-387f-434a-8760-374b5f89d7db)](https://dev.azure.com/bharathraj1614/cc21f1b1-ef46-4003-9419-7b6ac69c648b/_boards/board/t/f12ce632-e442-49c3-aa93-5db5e34fc3e4/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes AB#1. See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.